### PR TITLE
add option to modify the lookup used to match MIME type

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Thanks, Caroline
     npm install gulp-s3-upload
 
 ## Usage
-    
+
 Put in your AWS Developer key/secret. Region is optional.
 
     var gulp = require('gulp');
@@ -50,7 +50,7 @@ The bucket that the files will be uploaded to.
 
 Type: `string`
 
-See [Access Control List (ACL) Overview](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html) 
+See [Access Control List (ACL) Overview](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)
 for more information.  Defaults to 'public-read'.
 
 **gzip**
@@ -91,9 +91,28 @@ Example:
         ;
     });
 
+**mime_type_lookup**
+
+Type: `function`
+
+Use this to transform what the key that is used to match the MIME type when uploading to s3.
+
+Example:
+
+    gulp.task("upload_transform", function() {
+        gulp.src("./dir/to/upload/**")
+        .pipe(aws({
+            bucket: 'example-bucket',
+            mime_type_lookup: function(originalFilepath) {
+                return originalFilepath.replace('.gz', ''); //ignore gzip extension
+            },
+        }));
+    });
+
+
 ----------------------------------------------------
 
-### License 
+### License
 Copyright (c) 2014, [Caroline Amaba](mailto:caroline.amaba@gmail.com)
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function gulpPrefixer(AWS) {
 
             keyname = keyname.replace(/\\/g, "/");  // jic windows
 
-            var lookupKeyname = options.mimeTypeLookup ? options.mimeTypeLookup(keyname) : keyname;
+            var lookupKeyname = options.mime_type_lookup ? options.mime_type_lookup(keyname) : keyname;
 
             mimetype = mime.lookup(lookupKeyname);
 


### PR DESCRIPTION
Not sure about the API.  My use case for this is I need my gzipped files (which have a .gz extension) to be given the same MIME type as the underlying file (for example my files are `.js.gz` I'd like that to be MIME type of `application/javascript`).
