### PR TITLE
take in any aws config params instead of just the secret & key

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,21 +105,17 @@ function gulpPrefixer(AWS) {
 
 // Exporting the plugin main function
 module.exports = function(config) {
-    var aws_config = {};
+    var aws_config = config || {};
 
     aws_config.accessKeyId      = config.key;
     aws_config.secretAccessKey  = config.secret;
 
-    if(config.region) {
-        aws_config.region = config.region;
-    }
 
-    if(!config) {
+    if(!aws_config.accessKeyId || !aws_config.secretAccessKey) {
         throw new PluginError(PLUGIN_NAME, "Missing AWS Key & secret.");
-        return false;
     }
 
     AWS.config.update(aws_config);
 
     return gulpPrefixer(AWS);
-}
+};


### PR DESCRIPTION
This is a bit inelegant, but I wanted to support other aws config parameters.

Particularly signatureVersion, which is required to be specified as 'v4' when connecting to eu-central-1... but figured this would be a reasonable fix.
