### PR TITLE
Don't mutate the options object between files

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ gulpPrefixer = function(AWS) {
 
             var _stream = this,
                 keyTransform, keyname, keyparts, filename,
-                mimetype, mime_lookup_name;
+                mimetype, mime_lookup_name, metadata;
 
 
             if(file.isNull()) {
@@ -81,9 +81,9 @@ gulpPrefixer = function(AWS) {
 
             if(!options.Metadata && options.metadataMap) {
                 if(helper.isMetadataMapFn(options.metadataMap)) {
-                    options.Metadata = options.metadataMap(keyname);
+                    metadata = options.metadataMap(keyname);
                 } else {
-                    options.Metadata  =  options.metadataMap;
+                    metadata  =  options.metadataMap;
                 }
             } 
             //  options.Metdata is not filtered out later.
@@ -106,6 +106,7 @@ gulpPrefixer = function(AWS) {
                 objOpts.Key = keyname;
                 objOpts.Body = file.contents;
                 objOpts.ContentType = mimetype;
+                objOpts.Metadata = metadata;
                 
                 if(options.uploadNewFilesOnly && !getData || !options.uploadNewFilesOnly) {
 


### PR DESCRIPTION
Currently there's a bug in `metadataMap` - the metadataMap from the first file would be applied to app subsequent file. This is because the one `options` object is shared across all files, and then is mutated.

The `if(!options.Metadata && options.metadataMap){}` block will not be ran if `options.Metadata` exists, and then within that block, `options` is mutated to add `options.Metadata`, preventing it from updating for subsequent files. I fixed this my saving metadata into a new locally scoped `metadata` variable, and then saving that later into `objOpts.Metadata`.