### PR TITLE
Don't check accessKeyId and secretAccessKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,10 +159,6 @@ module.exports = function (config) {
     aws_config.secretAccessKey = config.secretAccessKey || config.secret;
 
 
-    if(!aws_config.accessKeyId || !aws_config.secretAccessKey) {
-        throw new PluginError(PLUGIN_NAME, "Missing AWS Key & Secret.");
-    }
-
     AWS.config.update(aws_config);
 
     return gulpPrefixer(AWS);


### PR DESCRIPTION
accessKeyId and secretAccessKey are not required when we run our
application on Amazon EC2 instances with IAM role.
http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html