### PR TITLE
Added async event stream map fixes #11

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var through     = require('through2')
+var es          = require('event-stream')
 ,   gutil       = require('gulp-util')
 ,   AWS         = require('aws-sdk')
 ,   mime        = require('mime')
@@ -26,7 +26,7 @@ gulpPrefixer = function (AWS) {
             throw new PluginError(PLUGIN_NAME, "Missing S3 bucket name!");
         }
 
-        stream = through.obj(function (file, enc, callback) {
+        stream = es.map(function (file, callback) {
 
             var _stream = this,
                 keyTransform, keyname, keyparts, filename,

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "homepage": "https://github.com/clineamb/gulp-s3-upload",
   "dependencies": {
     "aws-sdk": "2.1.17",
+    "event-stream": "^3.3.1",
     "gulp-util": "^3.0.4",
     "https-proxy-agent": "^0.3.5",
     "mime": "1.3.4",
-    "through2": "0.6.3",
     "underscore": "1.8.2"
   }
 }


### PR DESCRIPTION
Fixes #11

![enhanced-14836-1414320930-8](https://cloud.githubusercontent.com/assets/678372/8887099/9599543c-326d-11e5-8621-6e4daf48ff37.jpg)

...but I've been able to make this plugin asynchronous.
I took a look at some other gulp-plugins and came across https://www.npmjs.com/package/event-stream which has an async `map` function https://www.npmjs.com/package/event-stream#map-asyncfunction

I've dropped the dependency on `through2` and replaced it with `event-stream` and now all the files in the stream are processed asynchronously. :tada: 