### PR TITLE
Add ability to set custom Content-Encoding header on a per file basis

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # gulp-s3-upload
 __Version 1.1.2__
 
-Use for uploading assets to Amazon S3 servers.  
+Use for uploading assets to Amazon S3 servers.
 This helps to make it an easy gulp task.
 
 This package uses the [aws-sdk (node)](http://aws.amazon.com/sdk-for-node-js/).
@@ -78,20 +78,20 @@ Type: `string`
 
 Use this to add a charset to the mimetype. `"charset=[CHARSET]"` gets appended to the mimetype if this is defined.
 
-### etag_hash 
+### etag_hash
 
 Type: `string`
 
 Default: `'md5'`
 
-Use this to change the hashing of the files' ETags. The default is MD5.  More information on AWS's [Common Response Headers can be found here](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html).  You shouldn't have to change this, but AWS says the "ETag may or may not be an MD5 diest of the object data", so this option has been implemented should any other case arise. 
+Use this to change the hashing of the files' ETags. The default is MD5.  More information on AWS's [Common Response Headers can be found here](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html).  You shouldn't have to change this, but AWS says the "ETag may or may not be an MD5 diest of the object data", so this option has been implemented should any other case arise.
 
 
 #### keyTransform (nameTransform)
 
 Type: `function`
 
-Use this to transform your file names before they're uploaded to your S3 bucket.  
+Use this to transform your file names before they're uploaded to your S3 bucket.
 (Previously known as `name_transform`).
 
 ```js
@@ -207,6 +207,44 @@ Set `uploadNewFilesOnly: true` if you only want to upload new files and not
 overwrite existing ones.
 
 
+#### manualContentEncoding
+
+Type: `string` or `function`
+
+If you want to add a custom content-encoding header on a per file basis, you can
+define a function that determines the content encoding based on the keyname.
+Defining a `string` is like passing the `s3.putObject` param option `ContentEncoding`.
+
+Example (passing a `string`):
+```js
+    gulp.task("upload", function() {
+        gulp.src("./dir/to/upload/**")
+        .pipe(s3({
+            Bucket: 'example-bucket',
+            ACL: 'public-read',
+            manualContentEncoding: 'gzip'
+        }));
+    });
+```
+
+Example (passing a `function`):
+```js
+    gulp.task("upload", function() {
+        gulp.src("./dir/to/upload/**")
+        .pipe(s3({
+            Bucket: 'example-bucket',
+            ACL: 'public-read',
+            manualContentEncoding: function(keyname) {
+                var contentEncoding = null;
+
+                if (keyname.indexOf('.gz') !== -1) {
+                  contentEncoding = 'gzip';
+                }
+                return contentEncoding;
+            }
+        }));
+    });
+```
 
 ## AWS-SDK References
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ gulpPrefixer = function (AWS) {
         stream = es.map(function (file, callback) {
 
             var keyTransform, keyname, keyparts, filename,
-                mimetype, mime_lookup_name, metadata
+                mimetype, mime_lookup_name, metadata, contentEncoding
             ;
 
             if(file.isNull()) {
@@ -70,7 +70,7 @@ gulpPrefixer = function (AWS) {
                 keyname  = helper.buildName(keyparts.dirname, keyparts.basename + keyparts.extname);
             }
 
-            
+
             keyname = keyname.replace(/\\/g, "/"); // JIC Windows (uses backslashes)
 
 
@@ -97,7 +97,7 @@ gulpPrefixer = function (AWS) {
             //  ONLY if `options.Metadata` is undefined.
 
             if (!options.Metadata && options.metadataMap) {
-                if (helper.isMetadataMapFn(options.metadataMap)) {
+                if (helper.isFunction(options.metadataMap)) {
                     metadata = options.metadataMap(keyname);
                 } else {
                     metadata = options.metadataMap;
@@ -107,7 +107,7 @@ gulpPrefixer = function (AWS) {
             //  === ETag Hash Comparison =============================
             //  *NEW* in 1.1; do a local hash comparison to reduce
             //  the overhead from calling upload anyway.
-            //  Add the option for a different algorithm, JIC for 
+            //  Add the option for a different algorithm, JIC for
             //  some reason the algorithm is not MD5.
             //  Available algorithms are those available w/ default
             //  node `crypto` plugin. (run `crypto.getCiphers()`)
@@ -115,6 +115,16 @@ gulpPrefixer = function (AWS) {
             if(!options.etag_hash) {
                 //  If not defined, default to md5
                 options.etag_hash = 'md5';
+            }
+
+            // == Add manual content encoding
+            //
+            if (!options.ContentEncoding && options.manualContentEncoding) {
+                if(helper.isFunction(options.manualContentEncoding)) {
+                    contentEncoding = options.manualContentEncoding(keyname);
+                } else {
+                    contentEncoding = options.manualContentEncoding;
+                }
             }
 
             hasha.fromFile(path.join(file.base, file.relative),
@@ -147,11 +157,12 @@ gulpPrefixer = function (AWS) {
 
                         objOpts = helper.filterOptions(options);
 
-                        objOpts.Bucket      = the_bucket;
-                        objOpts.Key         = keyname;
-                        objOpts.Body        = file.contents;
-                        objOpts.ContentType = mimetype;
-                        objOpts.Metadata    = metadata;
+                        objOpts.Bucket          = the_bucket;
+                        objOpts.Key             = keyname;
+                        objOpts.Body            = file.contents;
+                        objOpts.ContentType     = mimetype;
+                        objOpts.Metadata        = metadata;
+                        objOpts.ContentEncoding = contentEncoding;
 
                         if (options.uploadNewFilesOnly && !head_data || !options.uploadNewFilesOnly) {
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -29,6 +29,7 @@ module.exports = {
             'Key',
             'keyTransform',
             'metadataMap',
+            'manualContentEncoding',
             'mimeTypeLookup',
             'nameTransform',
             'uploadNewFilesOnly',
@@ -38,7 +39,7 @@ module.exports = {
         return _.omit(params, omit_array);
     },
 
-    isMetadataMapFn: function (metadataMap) {
-        return _.isFunction(metadataMap);
+    isFunction: function (fn) {
+        return _.isFunction(fn);
     }
 };


### PR DESCRIPTION
Like `metadataMap`, `manualContentEncoding` allows you to set the `Content-Encoding` header using some arbitrary logic in a function:

```js
    gulp.task("upload", function() {
        gulp.src("./dir/to/upload/**")
        .pipe(s3({
            Bucket: 'example-bucket',
            ACL: 'public-read',
            manualContentEncoding: function(keyname) {
                var contentEncoding = null;

                if (keyname.indexOf('.gz') !== -1) {
                  contentEncoding = 'gzip';
                }
                return contentEncoding;
            }
        }));
    });
```

This is useful for when S3's auto content encoding detection won't work for you (like when you need to support gzipped files on older browsers where the extension needs to be `.gz.js` and not `.js.gz`).