### PR TITLE
add callback options to react to upload

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -142,6 +142,27 @@ Use this to transform your file names before they're uploaded to your S3 bucket.
 
 Type: `object` + `function`
 
+
+#### onChange
+
+Type: `function`
+
+This function gets called with the S3 keyname as the first parameter if the uploaded file resulted in a change.
+
+
+#### onNoChange
+
+Type: `function`
+
+This function gets called with the S3 keyname as the first parameter if the uploaded file did not result in a change.
+
+
+#### onNew
+
+Type: `function`
+
+This function gets called with the S3 keyname as the first parameter if the uploaded file is a new file in the bucket.
+
 **NEW IN 1.3**
 
 Upon reviewing an issue with `metadataMap` and `manualContentEncoding`, a standard method for mapping each `s3.putObject` param was created. For now, `metadataMap` and `manualContentEncoding` are still available, but they will be depricated in the next major version (2.0).

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ gulpPrefixer = function (AWS) {
 
             //  === manualContentEncoding ===========================
             //  Similar to metadataMap to put global / individual
-            //  headers on each file object (only if 
+            //  headers on each file object (only if
             //  options.ContentEncoding) is undefined. (1.2)
             //  ** WILL DEPRICATE IN 2.0.0 **
 
@@ -118,8 +118,8 @@ gulpPrefixer = function (AWS) {
                 options.ContentEncoding = options.manualContentEncoding;
             }
 
-            //  Check the file that's up in the bucket already 
-            
+            //  Check the file that's up in the bucket already
+
             _s3.headObject({
                 'Bucket': the_bucket,
                 'Key': keyname
@@ -159,7 +159,7 @@ gulpPrefixer = function (AWS) {
                     objOpts.Bucket          = the_bucket;
                     objOpts.Key             = keyname;
                     objOpts.Body            = file.contents;
-                    
+
                     if(mimetype.length) {
                         //  A check in case of map ContentType
                         objOpts.ContentType     = mimetype;
@@ -207,12 +207,21 @@ gulpPrefixer = function (AWS) {
                             if (head_data) {
                                 if (head_data.ETag !== data.ETag) {
                                     gutil.log(gutil.colors.yellow("Updated ....... "), keyname);
+                                    if (options.onChange && typeof options.onChange === 'function') {
+                                      options.onChange.call(this, keyname);
+                                    }
                                 } else {
                                     gutil.log(gutil.colors.gray("No Change ..... "), keyname);
+                                    if (options.onNoChange && typeof options.onNoChange === 'function') {
+                                      options.onNoChange.call(this, keyname);
+                                    }
                                 }
                             } else {
                                 // Doesn't exist in bucket; the object is new to the bucket
                                 gutil.log(gutil.colors.green("Uploaded! ..... "), keyname);
+                                if (options.onNew && typeof options.onNew === 'function') {
+                                  options.onNew.call(this, keyname);
+                                }
                             }
 
                             callback(null);

--- a/src/helper.js
+++ b/src/helper.js
@@ -24,6 +24,9 @@ module.exports = {
             'maps',
             'mimeTypeLookup',
             'nameTransform',
+            'onChange',
+            'onNoChange',
+            'onNew',
             'uploadNewFilesOnly',
             'verbose'
         ];


### PR DESCRIPTION
This PR adds 3 callback options: 'onChange', 'onNoChange', 'onNew'. They get called after a file got uploaded to S3. This can be used to programatically purge a cache for example.