### PR TITLE
call onNoChange if etag matches on HEAD request

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,11 @@ gulpPrefixer = function (AWS) {
 
                     //  AWS ETag doesn't match local ETag
                     gutil.log(gutil.colors.gray("No Change ..... "), keyname);
+
+                    if (options.onNoChange && typeof options.onNoChange === 'function') {
+                      options.onNoChange.call(this, keyname);
+                    }
+
                     callback(null);
 
                 } else {


### PR DESCRIPTION
At the moment, onNoChange isn't called in all the right places. If a `HEAD` is sent and the response indicates that the remote resource is identical, the onNoChange callback should be invoked.