### PR TITLE
stream support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -374,6 +374,22 @@ Type: `boolean`
 Set `uploadNewFilesOnly: true` if you only want to upload new files and not
 overwrite existing ones.
 
+## Streams
+
+When uploading large files you may want to use `gulp.src` without buffers. Normally this plugin calculates an ETag hash of the contents and compares that to the existing files in the bucket. However, when using streams, we can't do this comparison.
+
+Furthermore, the AWS SDK requires us to have a `ContentLength` in bytes of contents uploaded as a stream. This means streams are currently only supported for gulp sources that indicate the file size in `file.stat.size`, which is automatic when using a file system source.
+
+Example:
+```js
+    gulp.task("upload", function() {
+        gulp.src("./dir/to/upload/**", {buffer:false}) // buffer:false for streams
+        .pipe(s3({
+            Bucket: 'example-bucket',
+            ACL: 'public-read'
+        }));
+    });
+```
 
 ## AWS-SDK References
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/clineamb/gulp-s3-upload",
   "dependencies": {
-    "aws-sdk": "2.2.42",
+    "aws-sdk": "2.3.3",
     "event-stream": "^3.3.2",
     "gulp-util": "^3.0.7",
     "hasha": "^2.2.0",


### PR DESCRIPTION
We upload large video files using this plugin and need stream support. It appears the S3 API supports it, so the only thing stopping us is the ETag comparison. This PR does not do ETag comparison when handling streams.