### PR TITLE
fix(config): allow charset to be set always

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ gulpPrefixer = function (AWS) {
             // JIC text files get garbled. Appends to mimetype.
             // `charset` field gets filtered out later.
 
-            if (options.charset && mimetype == 'text/html') {
+            if (options.charset) {
                 mimetype += ';charset=' + options.charset;
             }
 


### PR DESCRIPTION
I'm using this to upload Javascript files to S3. After a lot of head-scratching, as the docs said I could add a `charset` parameter but it wasn't being used, I found that there is a filter to only allow charset for HTML files. Not sure why that would be.