### PR TITLE
Specify the version of event-stream to 3.3.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "ansi-colors": "^1.0.1",
     "aws-sdk": "^2.88.0",
-    "event-stream": "^3.3.4",
+    "event-stream": "3.3.4",
     "fancy-log": "^1.3.2",
     "hasha": "^3.0.0",
     "https-proxy-agent": "^2.0.0",


### PR DESCRIPTION
The version above contains a malware. cf https://github.com/dominictarr/event-stream/issues/116