### PR TITLE
Uses new mime function getType instead of lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ gulpPrefixer = function (AWS) {
                 mime_lookup_name = options.mimeTypeLookup(keyname);
             }
 
-            mimetype = mime.lookup(mime_lookup_name);
+            mimetype = mime.getType(mime_lookup_name);
 
             // === Charset ==========================================
             // JIC text files get garbled. Appends to mimetype.


### PR DESCRIPTION
Mime v2 has breaking changes. One of them is `lookup` function. As result after the bump package version on [this commit](https://github.com/jozecuervo/gulp-s3-upload/commit/b3076387e873a92eae2d8402dccdb84d9ef44ac5) we cannot use the package anymore. In this PR I replaced the old `lookup` with the new one, `getType` and now playing as expected.

[Mime breaking changes](https://www.npmjs.com/package/mime)